### PR TITLE
no longer build-depend on python2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+capnproto (0.7.0-4) UNRELEASED; urgency=medium
+
+  [ Tom Lee ]
+  * Add a few simple compile + link integration tests
+
+  [ tony mancill ]
+  * Update Build-Depends to python3-all (Closes: #936272)
+  * Bump Standards-Version to 4.4.0
+
+ -- tony mancill <tmancill@debian.org>  Mon, 02 Sep 2019 12:48:26 -0700
+
 capnproto (0.7.0-3) unstable; urgency=medium
 
   * Add missing binaries (Closes: #919180)

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Tom Lee <debian@tomlee.co>
 Build-Depends: debhelper (>= 11), gcc (>= 4.7), python3-all,
  dpkg-dev (>= 1.16.1.1), docbook-xsl, docbook-xml, xsltproc, netbase, cmake
-Standards-Version: 4.3.0
+Standards-Version: 4.4.0
 Homepage: https://capnproto.org/
 Vcs-Git: https://github.com/thomaslee/capnproto-debian
 Vcs-Browser: https://github.com/thomaslee/capnproto-debian

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: capnproto
 Section: devel
 Priority: optional
 Maintainer: Tom Lee <debian@tomlee.co>
-Build-Depends: debhelper (>= 11), gcc (>= 4.7), python-all (>= 2.6),
+Build-Depends: debhelper (>= 11), gcc (>= 4.7), python3-all,
  dpkg-dev (>= 1.16.1.1), docbook-xsl, docbook-xml, xsltproc, netbase, cmake
 Standards-Version: 4.3.0
 Homepage: https://capnproto.org/


### PR DESCRIPTION
Hi Tom,

I don't see any problems building capnproto against Python3, hence there's not much needed to resolve https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=936272.

Do you have thoughts on https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=837126?  Would you mind if I pushed a few more packaging changes before we upload 0.7.0-4?

Cheers,
tony