### PR TITLE
Setting upstream-vcs-tag breaks import-orig

### DIFF
--- a/debian/gbp.conf
+++ b/debian/gbp.conf
@@ -2,4 +2,3 @@
 pristine-tar = True
 debian-branch = debian/master
 upstream-branch = upstream/latest
-upstream-vcs-tag = %(version)s


### PR DESCRIPTION
@tmancill While I was getting a feel for how my usual workflows work wrt new branching stuff I ran into an issue with this. I usually use `gbp import-orig --uscan` to pull in upstream release tarballs (not a sync with the upstream repo, if that makes sense). This config setting seems to break `import-orig` because the expected "upstream tag" (e.g. `0.9.1`) does not exist. Possible I'm just not grokking the expected workflow here but I _think_ this is what we want.