### PR TITLE
Minor housekeeping

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,7 @@ Build-Depends: cmake,
  zlib1g-dev
 Standards-Version: 4.6.0
 Homepage: https://capnproto.org/
-Vcs-Git: https://github.com/thomaslee/capnproto-debian.git
+Vcs-Git: https://github.com/thomaslee/capnproto-debian.git -b debian/master
 Vcs-Browser: https://github.com/thomaslee/capnproto-debian
 Rules-Requires-Root: no
 

--- a/debian/tests/cli-tests
+++ b/debian/tests/cli-tests
@@ -18,6 +18,7 @@ test_run_capnp_compile() {
   local SCHEMADIR="$(mktemp -d)"
   local SCHEMAFILE=foo.capnp
   local SCHEMA="${SCHEMADIR}/${SCHEMAFILE}"
+  trap RETURN EXIT "rm -rf '${SCHEMADIR}'"
 
   echo "${ID};
 


### PR DESCRIPTION
The `Git-Vcs` issue was pointed out by https://tracker.debian.org/pkg/capnproto