### PR TITLE
Add GH action to do a basic build of the package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+on:
+  push:
+    branches:
+      - debian/master
+  pull_request: {}
+
+jobs:
+  sid:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: jtdor/build-deb-action@v1.0.0
+        with:
+          docker-image: debian:unstable-slim
+          buildpackage-opts: --build=binary --no-sign
+


### PR DESCRIPTION
This is more of a smoke test `dpkg-buildpackage` than a full-fledged `sbuild && lintian && autopkgtest` but it's something. Maybe we can shore it up more later.