### PR TITLE
New GH workflow dir makes dpkg-source angry

### DIFF
--- a/debian/source/options
+++ b/debian/source/options
@@ -1,0 +1,1 @@
+extend-diff-ignore = "(^|/)(\.github)"


### PR DESCRIPTION
Repeat after me: I _will_ remember to run a `gbp buildpackage` before pushing GH workflow changes.