### PR TITLE
Run `gbp buildpackage` on PR/push/merge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: jtdor/build-deb-action@v1.0.0
-        with:
-          docker-image: debian:unstable-slim
-          buildpackage-opts: --build=binary --no-sign
+      # FIXME massive hack, just trying to see if this works
+      - name: build and test
+        run: |
+          set -ex
+          git fetch --all
+          git branch pristine-tar origin/pristine-tar
+          git branch upstream/latest origin/upstream/latest
+          CONTAINER_ID="$(docker run --rm --privileged --detach -e DEBIAN_FRONTEND=noninteractive -v "$GITHUB_WORKSPACE:/github/workspace" --workdir=/github/workspace debian:unstable-slim tail -f /dev/null)"
+          DEBARCH="$(docker exec "$CONTAINER_ID" dpkg --print-architecture)"
+          docker exec "$CONTAINER_ID" apt-get update
+          docker exec "$CONTAINER_ID" apt-get install -y git-buildpackage build-essential
+          docker exec "$CONTAINER_ID" apt-get build-dep -y .
+          docker exec "$CONTAINER_ID" gbp buildpackage --git-pristine-tar --git-no-sign-tags --git-upstream-tree=BRANCH --git-ignore-branch \
+            --git-postbuild='lintian -I $GBP_CHANGES_FILE'
+          # FIXME autopkgtest-schroot requires ephemeral schroot sessions. Set a "union-type" or use a tarball schroot
+          # autopkgtest $GBP_CHANGES_FILE -- schroot unstable-${DEBARCH}-sbuild; [ $? -eq 0 -o $? -eq 8 ]'
+          docker kill "$CONTAINER_ID"
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+capnproto (0.8.0-3) UNRELEASED; urgency=medium
+
+  * Add serde-tests autopkgtest
+  * Add files for CI automation (GitHub Actions)
+
+ -- Tom Lee <debian@tomlee.co>  Mon, 10 Jan 2022 12:08:47 -0800
+
 capnproto (0.8.0-2) unstable; urgency=medium
 
   * Upload to unstable (Closes: #1002975)


### PR DESCRIPTION
Slightly more comprehensive than the `dpkg-buildpackage` stuff (e.g. it picked up the fact I needed to bump the changelog) but decided not to use the `sbuild` builder to avoid needing to pull down a whole distro. And `autopkgtest` requires either a qemu VM or an schroot to do its thing and I just can't be bothered fighting with that right now. So this is "better" but still not as complete as I'd like.