### PR TITLE
Link against libatomic if it's present

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+capnproto (0.9.1-2) UNRELEASED; urgency=medium
+
+  * Add libatomic check for armel (Closes: #1005066)
+
+ -- Tom Lee <debian@tomlee.co>  Sat, 06 Feb 2022 09:15:02 -0800
+
 capnproto (0.9.1-1) experimental; urgency=medium
 
   * Add serde-tests autopkgtest

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 capnproto (0.9.1-2) UNRELEASED; urgency=medium
 
   * Add libatomic check for armel (Closes: #1005066)
+  * Add tests for atomics via kj::AtomicRefcounted
+  * Trap EXIT in build-tests
 
  -- Tom Lee <debian@tomlee.co>  Sat, 06 Feb 2022 09:15:02 -0800
 

--- a/debian/patches/07_libatomic.patch
+++ b/debian/patches/07_libatomic.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -198,6 +198,8 @@
+ # CapnProtoConfig.cmake.in needs this variable.
+ AC_SUBST(WITH_OPENSSL, $with_openssl)
+ 
++AC_SEARCH_LIBS([__atomic_load_8], [atomic])
++
+ AM_CONDITIONAL([HAS_FUZZING_ENGINE], [test "x$LIB_FUZZING_ENGINE" != "x"])
+ 
+ AC_CONFIG_FILES([Makefile] CAPNP_PKG_CONFIG_FILES CAPNP_CMAKE_CONFIG_FILES)

--- a/debian/patches/07_libatomic.patch
+++ b/debian/patches/07_libatomic.patch
@@ -1,11 +1,54 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -198,6 +198,8 @@
- # CapnProtoConfig.cmake.in needs this variable.
- AC_SUBST(WITH_OPENSSL, $with_openssl)
+@@ -16,6 +16,11 @@
  
-+AC_SEARCH_LIBS([__atomic_load_8], [atomic])
+ AM_INIT_AUTOMAKE([tar-ustar])
+ 
++AC_ARG_WITH([libatomic],
++  [AS_HELP_STRING([--with-libatomic],
++    [build by linking against libatomic @<:@default=check@:>@])],
++  [],[with_libatomic=check])
 +
+ AC_ARG_WITH([external-capnp],
+   [AS_HELP_STRING([--with-external-capnp],
+     [use the system capnp binary (or the one specified with $CAPNP) instead of compiling a new
+@@ -195,8 +200,19 @@
+ ])
+ AM_CONDITIONAL([BUILD_KJ_TLS], [test "$with_openssl" != no])
+ 
+-# CapnProtoConfig.cmake.in needs this variable.
++AS_IF([test "$with_libatomic" = check], [
++  AC_SEARCH_LIBS([__atomic_load_8], [atomic], [with_libatomic=yes], [with_libatomic=no])
++], [
++  AS_IF([test "$with_libatomic" = yes], [
++    AC_SEARCH_LIBS([__atomic_load_8], [atomic], [:], [
++      AC_MSG_ERROR([could not find libatomic])
++    ])
++  ])
++])
++
++# CapnProtoConfig.cmake.in needs these variables.
+ AC_SUBST(WITH_OPENSSL, $with_openssl)
++AC_SUBST(WITH_LIBATOMIC, $with_libatomic)
+ 
  AM_CONDITIONAL([HAS_FUZZING_ENGINE], [test "x$LIB_FUZZING_ENGINE" != "x"])
  
- AC_CONFIG_FILES([Makefile] CAPNP_PKG_CONFIG_FILES CAPNP_CMAKE_CONFIG_FILES)
+--- a/cmake/CapnProtoConfig.cmake.in
++++ b/cmake/CapnProtoConfig.cmake.in
+@@ -62,6 +62,16 @@
+   endif()
+ endif()
+ 
++if (@WITH_LIBATOMIC@)  # WITH_LIBATOMIC
++  include(CheckLibraryExists)
++  check_library_exists(atomic __atomic_load_8 "" FOUND_LIBATOMIC)
++  if (FOUND_LIBATOMIC)
++    list(APPEND CMAKE_REQUIRED_LIBRARIES "atomic")
++  else()
++    message(FATAL_ERROR "libatomic not found")
++  endif()
++endif()
++
+ include("${CMAKE_CURRENT_LIST_DIR}/CapnProtoTargets.cmake")
+ include("${CMAKE_CURRENT_LIST_DIR}/CapnProtoMacros.cmake")
+ 

--- a/debian/patches/07_libatomic.patch
+++ b/debian/patches/07_libatomic.patch
@@ -1,3 +1,6 @@
+Description: link against libatomic
+Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1005066
+
 --- a/configure.ac
 +++ b/configure.ac
 @@ -16,6 +16,11 @@

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -2,3 +2,4 @@
 02_fixup_cmake.patch
 03_fix_typos.patch
 06_tests_fail_with_ipv6.patch
+07_libatomic.patch

--- a/debian/tests/atomic-tests
+++ b/debian/tests/atomic-tests
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+exec 2>&1
+
+set -e
+
+ATOMIC_PROGRAM_1='
+#include <iostream>
+#include <kj/refcount.h>
+
+class IntRef : public kj::AtomicRefcounted {
+public:
+  IntRef(int value) : kj::AtomicRefcounted(), value_(value) {}
+  virtual ~IntRef() {}
+
+  kj::Own<IntRef> addRef() {
+    return kj::atomicAddRef(*this);
+  }
+
+  int value() { return value_; }
+  int value() const { return value_; }
+
+private:
+  int value_;
+};
+
+int
+main (int argc, char **argv) {
+  auto arc1 = kj::atomicRefcounted<IntRef>(123);
+  auto arc2 = arc1->addRef();
+  std::cout << arc2->value() << std::endl;
+  return 0;
+}
+'
+
+test_pkgconfig_compile() {
+  local WORKDIR="$(mktemp -d)"
+  trap "rm -rf '$WORKDIR'" RETURN EXIT
+
+  echo "$ATOMIC_PROGRAM_1" >"$WORKDIR/pkgconfig-test.cc"
+
+  g++ -Wall -Werror \
+    $(pkg-config --cflags kj) \
+    -o "$WORKDIR/pkgconfig-test" \
+    "$WORKDIR/pkgconfig-test.cc" \
+    $(pkg-config --libs kj)
+
+  if [[ "$?" != 0 ]]; then
+    fail "compile failed"
+  fi
+
+  assertEquals "123" "$("$WORKDIR/pkgconfig-test")"
+}
+
+test_cmake_compile() {
+  local WORKDIR="$(mktemp -d)"
+  trap "rm -rf '$WORKDIR'" RETURN EXIT
+
+  echo "$ATOMIC_PROGRAM_1" >"$WORKDIR/cmake-test.cc"
+
+  echo '
+CMAKE_MINIMUM_REQUIRED(VERSION 3.2)
+
+project(cmake_test)
+
+find_package(CapnProto REQUIRED)
+
+include_directories(${CAPNP_INCLUDE_DIRS})
+add_definitions(${CAPNP_DEFINITIONS})
+add_executable(cmake-test cmake-test.cc)
+target_link_libraries(cmake-test ${CAPNP_LIBRARIES})
+' >"$WORKDIR/CMakeLists.txt"
+
+  if ! (cd "$WORKDIR" && cmake . && VERBOSE=1 make); then
+    fail "compile failed"
+  fi
+
+  assertEquals "123" "$("$WORKDIR/cmake-test")"
+}
+
+. shunit2
+

--- a/debian/tests/build-tests
+++ b/debian/tests/build-tests
@@ -35,7 +35,7 @@ main (int argc, char **argv)
 
 test_pkgconfig_compile() {
   local WORKDIR="$(mktemp -d)"
-  trap "rm -rf '$WORKDIR'" RETURN
+  trap "rm -rf '$WORKDIR'" RETURN EXIT
 
   echo "$EXAMPLE_PROGRAM_1" >"$WORKDIR/pkgconfig-test.cc"
 
@@ -54,7 +54,7 @@ test_pkgconfig_compile() {
 
 test_cmake_compile() {
   local WORKDIR="$(mktemp -d)"
-  trap "rm -rf '$WORKDIR'" RETURN
+  trap "rm -rf '$WORKDIR'" RETURN EXIT
 
   echo "$EXAMPLE_PROGRAM_1" >"$WORKDIR/cmake-test.cc"
   echo '
@@ -79,7 +79,7 @@ target_link_libraries(cmake-test ${CAPNP_LIBRARIES})
 
 test_version() {
   local WORKDIR="$(mktemp -d)"
-  trap "rm -rf '$WORKDIR'" RETURN
+  trap "rm -rf '$WORKDIR'" RETURN EXIT
 
   echo "$EXAMPLE_PROGRAM_2" >"$WORKDIR/version-test.cc"
 

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,2 +1,2 @@
-Tests: cli-tests, build-tests, serde-tests
+Tests: cli-tests, build-tests, serde-tests, atomic-tests
 Depends: @, shunit2, bash, g++, pkg-config, cmake


### PR DESCRIPTION
@tmancill this needs hardening/polish before we land it (and probably more still before we send it upstream), but could you give it a crack on an armel/mipsel porterbox when you get a sec? 

Aside from the change itself one thing I'm uncertain about is whether we need an explicit dependency on libatomic1 in the control file, it appears to be getting installed transitively by sbuild (at least on the armel build box).